### PR TITLE
Updated text about URI path and query components

### DIFF
--- a/draft-keranen-t2trg-rest-iot.md
+++ b/draft-keranen-t2trg-rest-iot.md
@@ -84,9 +84,7 @@ Transfer (REST) architectural style.
 
 The Representational State Transfer (REST) architectural style {{REST}} is a set of guidelines and best practices for building distributed hypermedia systems.
 
-When REST principles are applied to the design of a system, the result is
-often called RESTful and in particular an API following these principles is 
-called a RESTful API.
+When REST principles are applied to the design of a system, the result is often called RESTful and in particular an API following these principles is called a RESTful API.
 
 Different protocols can be used with RESTful systems, but at the time of writing the most common protocols are HTTP {{RFC7230}} and CoAP {{RFC7252}}.
 
@@ -267,12 +265,12 @@ Uniform Resource Identifiers (URIs) are used to indicate a resource for interact
        |           |            |            |        |
     scheme     authority       path        query   fragment
 
-A URI is a sequence of characters that matches the syntax defined in {{RFC3986}}. It consists of a hierarchical sequence of five components: scheme, authority, path, query, and fragment (from most significant to least significant). A scheme creates a namespace for resources and defines how the following components identify a resource within that namespace. The authority identifies an entity that governs part of the namespace, such as the server "www.example.org" in the "http" scheme. A host name (e.g., a fully qualified domain name) or an IP address, potentially followed by a transport layer port number, are usually used in the authority component for the "http" and "coap" schemes. The path and query contain data to identify a resource within the scope of the URI's scheme and naming authority. The path is hierarchical; the query is non-hierarchical. The fragment allows to refer to some portion of the resource, such as a section in an HTML document.
+A URI is a sequence of characters that matches the syntax defined in {{RFC3986}}. It consists of a hierarchical sequence of five components: scheme, authority, path, query, and fragment (from most significant to least significant). A scheme creates a namespace for resources and defines how the following components identify a resource within that namespace. The authority identifies an entity that governs part of the namespace, such as the server "www.example.org" in the "http" scheme. A host name (e.g., a fully qualified domain name) or an IP address, potentially followed by a transport layer port number, are usually used in the authority component for the "http" and "coap" schemes. The path and query contain data to identify a resource within the scope of the URI's scheme and naming authority. The fragment allows to refer to some portion of the resource, such as a section in an HTML document.
 
 For RESTful IoT applications, typical schemes include "https", "coaps", "http", and "coap". These refer to HTTP and CoAP, with and without Transport Layer Security (TLS) {{RFC5246}}. (CoAP uses Datagram TLS (DTLS) {{RFC6347}}, the variant of TLS for UDP.) These four schemes also provide means for locating the resource; using the HTTP protocol for "http" and "https", and with the CoAP protocol for "coap" and "coaps". If the scheme is different for two URIs (e.g., "coap" vs. "coaps"), it is important to note that even if the rest of the URI is identical, these are two different resources, in two distinct namespaces.
 
 The query parameters can be used to parametrize the resource. For example, a GET request may use query parameters to request the server to send only certain kind data of the resource (i.e., filtering the response). Query parameters in PUT and POST requests do not have such established semantics and are not commonly used.
-
+Whether the order of the query parameters matters in URIs is unspecified and they can be re-ordered e.g., by proxies. Therefore applications should not rely on their order; see Section 3.3 of {{?RFC6943}} for more details.
 
 ## HTTP/CoAP Methods {#sec-methods}
 
@@ -333,7 +331,7 @@ This document does not define new functionality and therefore does not introduce
 
 # Acknowledgement
 
-The authors would like to thank Mert Ocak, Heidi-Maria Back, Tero Kauppinen, and Michael Koster for the reviews and feedback.
+The authors would like to thank Mert Ocak, Heidi-Maria Back, Tero Kauppinen, Michael Koster, Robby Simpson, Ravi Subramaniam, and Dave Thaler for the reviews and feedback.
 
 --- back
 


### PR DESCRIPTION
Removed "path is hierarchical query not" comment.
Added note about query component order being unspecified.